### PR TITLE
Added attributes to the list of Region props

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -31,7 +31,7 @@ export const Region = ({
   // TODO: may need some improvements
   useEffect(() => {
     if (regionRef) {
-      let update = ["start", "end", "color", "data", "drag", "resize"].reduce(
+      let update = ["start", "end", "color", "data", "drag", "resize", "attributes"].reduce(
         (result, prop) => {
           if (regionRef[prop] !== props[prop]) {
             return {
@@ -53,7 +53,8 @@ export const Region = ({
     props.color,
     props.data,
     props.resize,
-    props.drag
+    props.drag,
+    props.attributes
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This is so that I can add attributes that are then used in a ::before css rule so that I can display and update text on a region. Before adding this, the text would initially render, but never get updated.

This should be a pretty simple and straightforward change.