### PR TITLE
Include all updatable Region props when sending updates

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -2,6 +2,20 @@ import { useContext, useState, useEffect, useRef } from "react";
 import useRegionEvent from "../hooks/useRegionEvent";
 import WaveSurferContext from "../contexts/WaveSurferContext";
 
+const UpdatableRegionProps = [
+  "start",
+  "end",
+  "loop",
+  "color",
+  "handleStyle",
+  "data",
+  "resize",
+  "drag",
+  "maxLength",
+  "minLength",
+  "attributes"
+]
+
 export const Region = ({
   onOver,
   onLeave,
@@ -31,7 +45,7 @@ export const Region = ({
   // TODO: may need some improvements
   useEffect(() => {
     if (regionRef) {
-      let update = ["start", "end", "color", "data", "drag", "resize", "attributes"].reduce(
+      let update = UpdatableRegionProps.reduce(
         (result, prop) => {
           if (regionRef[prop] !== props[prop]) {
             return {

--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -61,15 +61,7 @@ export const Region = ({
 
       regionRef.update(update);
     }
-  }, [
-    props.start,
-    props.end,
-    props.color,
-    props.data,
-    props.resize,
-    props.drag,
-    props.attributes
-  ]);
+  }, UpdatableRegionProps.map(prop => props[prop]));
 
   useEffect(() => {
     if (!isRenderedCache.current && waveSurfer) {


### PR DESCRIPTION
I had a bug caused by `minLength` and `maxLength` being excluded from the list of updatable props inside the Region component. As a fix I've had a look inside Wavesurfer's code and added all of the props they check in their `update` function ([see here](https://github.com/katspaugh/wavesurfer.js/blob/master/src/plugin/regions/region.js#L90-L129)).