### PR TITLE
Region DoubleClick Event Typo Fix

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -86,7 +86,7 @@ export const Region = ({
 
   useRegionEvent(regionRef, "leave", onLeave);
 
-  useRegionEvent(regionRef, "dbclick", onDoubleClick);
+  useRegionEvent(regionRef, "dblclick", onDoubleClick);
 
   useRegionEvent(regionRef, "in", onIn);
 


### PR DESCRIPTION
There was a typo in Region.js, @Line 89 -> which caused the double click event to not trigger on a region.

changed "dbclick" to "dblclick"

