### PR TITLE
Correcting function to support false prop values

### DIFF
--- a/src/utils/getWaveFormOptionsFromProps.js
+++ b/src/utils/getWaveFormOptionsFromProps.js
@@ -51,7 +51,7 @@ const waveFormPropsList = [
 const getWaveFormOptionsFromProps = props => {
   if (!props) return {};
   return waveFormPropsList.reduce((waveFormOptions, optionName) => {
-    if (!props[optionName]) {
+    if (!props.hasOwnProperty(optionName)) {
       return waveFormOptions;
     }
 


### PR DESCRIPTION
Right now the `getWaveFormOptionsFromProps()` function is not properly adding a key/value pair if the value found is a `false` value.  The `!props[optionName]` logic is evaluating as TRUE if the value of props[optionName] is a value of false, and then returning back waveFormOptions unmodified.

You can see it return an empty object here: https://jsfiddle.net/tv3gnmpb/