### PR TITLE
update event names

### DIFF
--- a/src/components/Region.tsx
+++ b/src/components/Region.tsx
@@ -88,9 +88,9 @@ export const Region = ({
 
   useRegionEvent(regionRef, "click", onClick);
 
-  useRegionEvent(regionRef, "over", onOver);
+  useRegionEvent(regionRef, "mouseenter", onOver);
 
-  useRegionEvent(regionRef, "leave", onLeave);
+  useRegionEvent(regionRef, "mouseleave", onLeave);
 
   useRegionEvent(regionRef, "dblclick", onDoubleClick);
 


### PR DESCRIPTION
I could not get the OnOver and OnLeave events to trigger. All of the events used with `useRegionEvent` except for 'over' and 'leave' are present in [region.js](https://github.com/katspaugh/wavesurfer.js/blob/master/src/plugin/regions/region.js). The events not accounted for in that file are `mouseenter` and `mouseleave`. I'm not sure how to test this update but I have hopes that it'll allow for those event handlers to trigger.