### PR TITLE
- remove defaultProps from WaveSurfer.tsx

### DIFF
--- a/src/containers/WaveSurfer.tsx
+++ b/src/containers/WaveSurfer.tsx
@@ -29,9 +29,4 @@ function WaveSurfer<GPlug extends GenericPlugin>({ children, plugins = [], onMou
   );
 }
 
-WaveSurfer.defaultProps = {
-  children: null,
-  plugins: [],
-};
-
 export default WaveSurfer;


### PR DESCRIPTION
DefaultProps are no longer supported in future React Versions and throws error since React 18.3.1

https://react.dev/blog/2024/04/25/react-19-upgrade-guide